### PR TITLE
Ubuntu added variable_tests for kernel advisories

### DIFF
--- a/oval/objects.go
+++ b/oval/objects.go
@@ -7,7 +7,7 @@ import (
 
 func (o *Objects) init() {
 	var wg sync.WaitGroup
-	wg.Add(6)
+	wg.Add(7)
 
 	go func() {
 		defer wg.Done()
@@ -57,6 +57,14 @@ func (o *Objects) init() {
 		}
 	}()
 
+	go func() {
+		defer wg.Done()
+		o.variableObjectMemo = make(map[string]int, len(o.VariableObjects))
+		for i, v := range o.VariableObjects {
+			o.variableObjectMemo[v.ID] = i
+		}
+	}()
+
 	wg.Wait()
 }
 
@@ -81,6 +89,9 @@ func (o *Objects) Lookup(ref string) (kind string, index int, err error) {
 	}
 	if i, ok := o.rpmverifyfileMemo[ref]; ok {
 		return o.RPMVerifyFileObjects[i].XMLName.Local, i, nil
+	}
+	if i, ok := o.variableObjectMemo[ref]; ok {
+		return o.VariableObjects[i].XMLName.Local, i, nil
 	}
 
 	// We didn't find it, maybe we can say why.

--- a/oval/tests.go
+++ b/oval/tests.go
@@ -8,7 +8,7 @@ import (
 // Init sets up the memoization maps.
 func (t *Tests) init() {
 	var wg sync.WaitGroup
-	wg.Add(7)
+	wg.Add(8)
 
 	go func() {
 		defer wg.Done()
@@ -66,6 +66,14 @@ func (t *Tests) init() {
 		}
 	}()
 
+	go func() {
+		defer wg.Done()
+		t.variableTestMemo = make(map[string]int, len(t.VariableTests))
+		for i, v := range t.VariableTests {
+			t.variableTestMemo[v.ID] = i
+		}
+	}()
+
 	wg.Wait()
 }
 
@@ -94,6 +102,9 @@ func (t *Tests) Lookup(ref string) (kind string, index int, err error) {
 		return t.UnameTests[i].XMLName.Local, i, nil
 	}
 	if i, ok := t.textfilecontent54Memo[ref]; ok {
+		return t.TextfileContent54Tests[i].XMLName.Local, i, nil
+	}
+	if i, ok := t.variableTestMemo[ref]; ok {
 		return t.TextfileContent54Tests[i].XMLName.Local, i, nil
 	}
 

--- a/oval/types.go
+++ b/oval/types.go
@@ -245,6 +245,7 @@ type Tests struct {
 	RPMVerifyFileTests     []RPMVerifyFileTest     `xml:"rpmverifyfile_test"`
 	UnameTests             []UnameTest             `xml:"uname_test"`
 	TextfileContent54Tests []TextfileContent54Test `xml:"textfilecontent54_test"`
+	VariableTests          []VariableTest          `xml:"variable_test"`
 	lineMemo               map[string]int
 	version55Memo          map[string]int
 	rpminfoMemo            map[string]int
@@ -252,6 +253,7 @@ type Tests struct {
 	rpmverifyfileMemo      map[string]int
 	unameMemo              map[string]int
 	textfilecontent54Memo  map[string]int
+	variableTestMemo       map[string]int
 }
 
 // ObjectRef : >tests>line_test>object-object_ref
@@ -280,12 +282,14 @@ type Objects struct {
 	RPMInfoObjects           []RPMInfoObject           `xml:"rpminfo_object"`
 	RPMVerifyFileObjects     []RPMVerifyFileObject     `xml:"rpmverifyfile_object"`
 	DpkgInfoObjects          []DpkgInfoObject          `xml:"dpkginfo_object"`
+	VariableObjects          []VariableObject          `xml:"variable_object"`
 	lineMemo                 map[string]int
 	version55Memo            map[string]int
 	textfilecontent54Memo    map[string]int
 	rpminfoMemo              map[string]int
 	rpmverifyfileMemo        map[string]int
 	dpkginfoMemo             map[string]int
+	variableObjectMemo       map[string]int
 }
 
 // States : >states
@@ -298,6 +302,7 @@ type States struct {
 	DpkgInfoStates          []DpkgInfoState          `xml:"dpkginfo_state"`
 	TextfileContent54States []TextfileContent54State `xml:"textfilecontent54_state"`
 	RPMVerifyFileState      []RPMVerifyFileState     `xml:"rpmverifyfile_state"`
+	VariableStates          []VariableState          `xml:"variable_state"`
 	lineMemo                map[string]int
 	version55Memo           map[string]int
 	rpminfoMemo             map[string]int

--- a/oval/variable.go
+++ b/oval/variable.go
@@ -1,0 +1,28 @@
+package oval
+
+import "encoding/xml"
+
+// VariableTest : >tests>variable_test
+type VariableTest struct {
+	XMLName       xml.Name `xml:"variable_test"`
+	ID            string   `xml:"id,attr"`
+	StateOperator string   `xml:"state_operator,attr"`
+	Comment       string   `xml:"comment,attr"`
+	testRef
+}
+
+var _ Test = (*VariableTest)(nil)
+
+// VariableObject : >objects>variable_object
+type VariableObject struct {
+	XMLName xml.Name `xml:"variable_object"`
+	ID      string   `xml:"id,attr"`
+	VarRef  string   `xml:"var_ref"`
+}
+
+// VariableState : >states>variable_state
+type VariableState struct {
+	XMLName xml.Name `xml:"variable_state"`
+	ID      string   `xml:"id,attr"`
+	Value   string   `xml:"value"`
+}


### PR DESCRIPTION
These variable tests are currently not supported, but needed to parse Ubuntu OVAL kernel advisories correctly. Instead of just using a normal dpkginfo test they use variable objects with a variable test. This actually seems to be offspec usage, but canonical likes to do dumb shit.